### PR TITLE
Replace dotenv with python-dotenv

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -72,20 +72,6 @@ files = [
 ]
 
 [[package]]
-name = "dotenv"
-version = "0.9.9"
-description = "Deprecated package"
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "dotenv-0.9.9-py2.py3-none-any.whl", hash = "sha256:29cf74a087b31dafdb5a446b6d7e11cbce8ed2741540e2339c69fbef92c94ce9"},
-]
-
-[package.dependencies]
-python-dotenv = "*"
-
-[[package]]
 name = "h11"
 version = "0.16.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
@@ -410,14 +396,14 @@ typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
 name = "python-dotenv"
-version = "1.1.1"
-description = "Read key-value pairs from a .env file and set them as environment variables"
+version = "0.9.1"
+description = "Add .env support to your django/flask apps in development and deployments"
 optional = false
-python-versions = ">=3.9"
+python-versions = "*"
 groups = ["main"]
 files = [
-    {file = "python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc"},
-    {file = "python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab"},
+    {file = "python-dotenv-0.9.1.tar.gz", hash = "sha256:122290a38ece9fe4f162dc7c95cae3357b983505830a154d3c98ef7f6c6cea77"},
+    {file = "python_dotenv-0.9.1-py2.py3-none-any.whl", hash = "sha256:4a205787bc829233de2a823aa328e44fd9996fedb954989a21f1fc67c13d7a77"},
 ]
 
 [package.extras]
@@ -487,4 +473,4 @@ typing-extensions = ">=4.12.0"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.14"
-content-hash = "3f1a7f215b21020227db2c94918d95bd8eb1fcaae61c0dee6b611b23a8979b96"
+content-hash = "f453d0c36fe7fd274458ea582c1ecce189c186f00442c3930a491bc79e0ae008"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["Stanislav Poryadnyi <sporyadnyi@gmail.com>"]
 [tool.poetry.dependencies]
 python = ">=3.12,<3.14"
 openai = "^1.97.0"
-dotenv = "^0.9.9"
+python-dotenv = "^0.9.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## Summary
- replace deprecated `dotenv` with `python-dotenv` in `pyproject.toml`
- update `poetry.lock` via `poetry lock`

## Testing
- `poetry lock`

------
https://chatgpt.com/codex/tasks/task_e_687c5bfa71bc832dbdbcf59c88f3d2b1