### PR TITLE
Add pytest and tests for postprocessing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ python = ">=3.12,<3.14"
 openai = "^1.97.0"
 python-dotenv = "^0.9.0"
 
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.4"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -1,0 +1,27 @@
+import sys
+import types
+
+# Stub out optional dependencies used in main during import
+sys.modules.setdefault("openai", types.SimpleNamespace(OpenAI=lambda *a, **k: None))
+
+module = types.ModuleType("dotenv")
+module.load_dotenv = lambda *a, **k: None
+sys.modules.setdefault("dotenv", module)
+
+from main import postprocess_reply
+
+
+def test_remove_think_block():
+    text = "Hello<think>secret</think>World"
+    assert postprocess_reply(text) == "HelloWorld"
+    assert "<think>" not in postprocess_reply(text)
+
+
+def test_drop_starting_think():
+    text = "<think>I should not be seen"
+    assert postprocess_reply(text) == ""
+
+
+def test_strip_whitespace():
+    text = "  Hello world  "
+    assert postprocess_reply(text) == "Hello world"


### PR DESCRIPTION
## Summary
- configure pyproject with a dev dependency on pytest
- add a `tests` package and unit tests for `postprocess_reply`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687c5db4bb1c832db1c5786d8503e607